### PR TITLE
Prioritize watchlist

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -3,6 +3,5 @@
 class Asset < ApplicationRecord
   validates :symbol, presence: true, uniqueness: true
 
-  has_many :wallet_items
   has_one :last_quote, -> { where(quotes: { current: true }) }, class_name: 'Quote'
 end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -3,5 +3,6 @@
 class Asset < ApplicationRecord
   validates :symbol, presence: true, uniqueness: true
 
+  has_many :wallet_items
   has_one :last_quote, -> { where(quotes: { current: true }) }, class_name: 'Quote'
 end

--- a/app/services/update_quotes.rb
+++ b/app/services/update_quotes.rb
@@ -3,7 +3,8 @@
 class UpdateQuotes < ApplicationService
   def call
     Asset.all.each do |asset|
-      UpdateAssetQuoteWorker.perform_async(asset.symbol)
+      priority = WalletItem.find_by(asset: asset) ? :high : :default
+      UpdateAssetQuoteWorker.set(queue: priority).perform_async(asset.symbol)
     end
   end
 end

--- a/app/services/update_quotes.rb
+++ b/app/services/update_quotes.rb
@@ -2,8 +2,8 @@
 
 class UpdateQuotes < ApplicationService
   def call
-    Asset.all.each do |asset|
-      priority = WalletItem.find_by(asset: asset) ? :high : :default
+    Asset.includes(:wallet_items).all.each do |asset|
+      priority = asset.wallet_items.present? ? :high : :default
       UpdateAssetQuoteWorker.set(queue: priority).perform_async(asset.symbol)
     end
   end

--- a/app/services/update_quotes.rb
+++ b/app/services/update_quotes.rb
@@ -2,8 +2,10 @@
 
 class UpdateQuotes < ApplicationService
   def call
-    Asset.includes(:wallet_items).all.each do |asset|
-      priority = asset.wallet_items.present? ? :high : :default
+    asset_ids = WalletItem.distinct.pluck(:asset_id)
+
+    Asset.all.each do |asset|
+      priority = asset_ids.include? asset.id ? :high : :default
       UpdateAssetQuoteWorker.set(queue: priority).perform_async(asset.symbol)
     end
   end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,5 @@
+:concurrency: 5
+:queues:
+  - high
+  - default
+  - low


### PR DESCRIPTION
#### Tarefa 3 - Priorizar ativos que estão nas watchlist
* Os ativos que estão nas watchlists de usuários sempre devem ser processadas primeiro dos que não estão, ou seja, quando houver uma fila de cotações sendo processadas, os ativos que estão nas watchlists devem ser os primeiros dessa fila;